### PR TITLE
feat(readme): update is-not-a.dev to new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use the code: `STARTED20` for 20% off of your first month!
 ### Similar Projects
 - [is-a.dev](https://github.com/is-a-dev/register)
 - [thedev.id](https://github.com/fransallen/thedev.id)
-- [is-not-a.dev](https://is-not-a.dev)
+- [Open Domains](https://github.com/open-domains/register)
 - [is-really.cool](https://github.com/is-really-cool/register)
 - [cluster.ws & wip.la](https://github.com/Olivr/free-domain)
 - [js.org](https://github.com/js-org/js.org) (*JavaScript projects only*)


### PR DESCRIPTION
I saw your comment here: https://github.com/is-a-good-dev/register/pull/291#issuecomment-1336821633

But is-not-a.dev has been renamed to Open Domains as we now offer more domains, not just is-not-a.dev.