### PR TITLE
Update proxy to false due to `1014` error

### DIFF
--- a/sub-logs/kd.json
+++ b/sub-logs/kd.json
@@ -13,5 +13,5 @@
      }
   },
 
-  "proxied": true
+  "proxied": false
 }


### PR DESCRIPTION
I was getting a "Error 1014: CNAME Cross-User Banned", because my website is hosted on Cloudflare Pages. So settings proxy to `false` should solve it.