### PR TITLE
Add certbot DNS-01 challenge domain

### DIFF
--- a/sub-logs/ben.json
+++ b/sub-logs/ben.json
@@ -10,7 +10,7 @@
        "value": "benthetechguy.net"
      },
     "CNAME": {
-       "name": "_acme-challenge",
+       "name": "_acme-challenge.bob.is-a-good.dev",
        "value": "9a415aff-3d5e-41ad-93a1-f0e5986e088f.auth.acme-dns.io"
      }
   },

--- a/sub-logs/ben.json
+++ b/sub-logs/ben.json
@@ -8,6 +8,10 @@
     "CNAME": {
        "name": "ben", 
        "value": "benthetechguy.net"
+     },
+    "CNAME": {
+       "name": "_acme-challenge",
+       "value": "9a415aff-3d5e-41ad-93a1-f0e5986e088f.auth.acme-dns.io"
      }
   },
 


### PR DESCRIPTION
My ISP blocks port 80, so I can't do a normal Let's Encrypt HTTP-01 challenge to get a certificate for the domain. I get around this by instead using the DNS-01 challenge, which adds a CNAME record to prove that I have control of the domain so I can get the certificate.