### PR TITLE
update file json for vercel

### DIFF
--- a/domains/ztl.json
+++ b/domains/ztl.json
@@ -10,6 +10,11 @@
         "CNAME": {
             "name": "ztl",
             "value": "3dslider.vercel.app"
+        },
+        
+        "TXT": {
+            "name": "_vercel",
+            "value": "vc-domain-verify=ztl.is-a-good.dev,66dd316bd6eeeb3164a9"
         }
     },
 


### PR DESCRIPTION
Another Vercel account is using this domain. Set the following TXT record on _vercel.ztl.is-a-good.dev to use ztl.is-a-good.dev in this project. If you wish to transfer the entire domain, this will need to be done by the current domain owner. Once the verification is completed and the domain is successfully configured, the TXT record can be removed.