### PR TITLE
Fixed a small github pages verification issue on my `quack.json` entry

### DIFF
--- a/domains/quack.json
+++ b/domains/quack.json
@@ -15,7 +15,7 @@
             },
             {
                 "name": "_github-pages-challenge-PatoFlamejanteTV",
-                "value": "a200d9d62c5cf4522df304c1ca198e"
+                "value": "04a5aab8b9f884534f8b106f9b07d2"
             }
         ]
     },


### PR DESCRIPTION
Fixed the verification text contents thingy, also, is normal to this error to occur?

<img width="1041" height="526" alt="image" src="https://github.com/user-attachments/assets/343ce70e-ff47-4a28-80bc-ece057df7018" />
<img width="892" height="553" alt="image" src="https://github.com/user-attachments/assets/cdcac5d8-544e-41a7-a0ea-11798c94a2e4" />
