### PR TITLE
fix: removed Cloudflare proxy from erenay.json

### DIFF
--- a/domains/erenay.json
+++ b/domains/erenay.json
@@ -11,5 +11,5 @@
     }
   },
 
-  "proxied": true
+  "proxied": false
 }


### PR DESCRIPTION
Removed Cloudflare proxied status due to CNAME Cross-User Banned error