### PR TITLE
Im kinda confused rn...

### DIFF
--- a/domains/quack.json
+++ b/domains/quack.json
@@ -10,7 +10,7 @@
         },
         "TXT": [
             {
-                "name": "_discord.quack.is-a-good-dev",
+                "name": "_discord.quack",
                 "value": "dh=3471cf5f6e425d5631635f1492699c310991c178"
             },
             {

--- a/domains/quack.json
+++ b/domains/quack.json
@@ -14,7 +14,7 @@
                 "value": "dh=3471cf5f6e425d5631635f1492699c310991c178"
             },
             {
-                "name": "_github-pages-challenge-PatoFlamejanteTV",
+                "name": "_github-pages-challenge-PatoFlamejanteTV.quack",
                 "value": "04a5aab8b9f884534f8b106f9b07d2"
             }
         ]

--- a/domains/quack.json
+++ b/domains/quack.json
@@ -14,7 +14,7 @@
                 "value": "dh=3471cf5f6e425d5631635f1492699c310991c178"
             },
             {
-                "name": "_github-pages-challenge-PatoFlamejanteTV.quack",
+                "name": "_github-pages-challenge-patoflamejantetv.quack",
                 "value": "04a5aab8b9f884534f8b106f9b07d2"
             }
         ]


### PR DESCRIPTION
So, github page sis currently not recognizing my domain, and so i opened a ticket and the Github AI responded me this:

```
It looks like the TXT record you’ve added isn’t actually at the hostname GitHub Pages is checking for, which is why verification keeps failing.

When verifying a custom domain for GitHub Pages, the TXT record must be created exactly at:

_github-pages-challenge-PatoFlamejanteTV.quack.is-a-good.dev

From the JSON you shared, your TXT record is currently set at:

_github-pages-challenge-PatoFlamejanteTV.is-a-good.dev

(because "name": "_github-pages-challenge-PatoFlamejanteTV" in your config is relative to the zone is-a-good.dev).

That means GitHub is looking for the TXT record at the quack.is-a-good.dev subdomain, but it’s actually being published at the apex of is-a-good.dev, so it never matches.
How to fix it

You need to scope the TXT record to the quack subdomain in your DNS config.
In your JSON, that means changing the TXT record’s name to include quack:

{
    "name": "_github-pages-challenge-PatoFlamejanteTV.quack",
    "value": "04a5aab8b9f884534f8b106f9b07d2"
}

That will publish the TXT record at:

_github-pages-challenge-PatoFlamejanteTV.quack.is-a-good.dev

After updating

    Save and commit the change to the is-a-good-dev/register repo.
    Wait for the DNS to update (can be immediate or up to 24h).
    Confirm it’s live by running:

dig _github-pages-challenge-PatoFlamejanteTV.quack.is-a-good.dev TXT +nostats +nocomments +nocmd

You should see:

_github-pages-challenge-PatoFlamejanteTV.quack.is-a-good.dev.  IN TXT "04a5aab8b9f884534f8b106f9b07d2"

    Go back to your Pages settings and click Continue verifying → Verify.
```