### PR TITLE
fix: disable proxy for 526 error

### DIFF
--- a/domains/jdlanzaderas.json
+++ b/domains/jdlanzaderas.json
@@ -5,10 +5,10 @@
   },
 
   "target": {
-    "A": ["185.27.134.134"],
-    "CNAME": {
-      "554406a6ca5f828b1ebb5c3c2e2a8cfa": "ns1.byet.org"
-    }
+    "A": {
+       "name": "jdlanzaderas", 
+       "value": ["185.27.134.134"]
+     }
   },
 
   "proxied": false

--- a/domains/jdlanzaderas.json
+++ b/domains/jdlanzaderas.json
@@ -7,7 +7,7 @@
   "target": {
     "A": {
        "name": "jdlanzaderas", 
-       "value": ["185.27.134.134"]
+       "value": ["69.164.250.130"]
      }
   },
 

--- a/domains/jdlanzaderas.json
+++ b/domains/jdlanzaderas.json
@@ -4,7 +4,7 @@
     "email": "lanzaderasjohndiether83@gmail.com"
   },
 
-  "records": {
+  "target": {
     "A": ["185.27.134.134"],
     "CNAME": {
       "554406a6ca5f828b1ebb5c3c2e2a8cfa": "ns1.byet.org"

--- a/domains/jdlanzaderas.json
+++ b/domains/jdlanzaderas.json
@@ -4,12 +4,12 @@
     "email": "lanzaderasjohndiether83@gmail.com"
   },
 
-  "target": {
-    "A": {
-       "name": "jdlanzaderas", 
-       "value": ["185.27.134.134"]
-     }
+  "records": {
+    "A": ["185.27.134.134"],
+    "CNAME": {
+      "554406a6ca5f828b1ebb5c3c2e2a8cfa": "ns1.byet.org"
+    }
   },
 
-  "proxied": true
+  "proxied": false
 }


### PR DESCRIPTION
Updating `jdlanzaderas.json` to resolve issues:

- **Fixed SSL Error 526:** Switched to `"proxied": false` so that my InfinityFree ZeroSSL certificate can be recognized directly without the Cloudflare handshake conflict.

Thank you!