### PR TITLE
Add mova.is-a-good.dev

### DIFF
--- a/domains/mova.json
+++ b/domains/mova.json
@@ -1,0 +1,14 @@
+{
+  "repo": "https://github.com/Stonepath-dotcom/gutsytik",
+  "owner": {
+    "username": "Stonepath-dotcom",
+    "email": "ardiidonovan@gmail.com"
+  },
+  "target": {
+    "CNAME": {
+      "name": "mova",
+      "value": "cname.vercel-dns.com"
+    }
+  },
+  "proxied": false
+}


### PR DESCRIPTION
I would like to request the subdomain mova.is-a-good.dev for my video downloader project called Mova. It is a Next.js web application hosted on Vercel.

- Project repo: https://github.com/Stonepath-dotcom/gutsytik
- Live site: https://movadl.vercel.app
- The site is a video downloader without watermark that supports TikTok, YouTube, and other platforms.