### PR TITLE
Register helloplainly.is-a-good.dev

### DIFF
--- a/domains/helloplainly.json
+++ b/domains/helloplainly.json
@@ -1,7 +1,7 @@
 {
     "owner": {
         "username": "simbiont-ai",
-        "email": "TODO-SHEF-EMAIL"
+        "email": "dexlobster444@gmail.com"
     },
     "target": {
         "CNAME": {

--- a/domains/helloplainly.json
+++ b/domains/helloplainly.json
@@ -1,0 +1,13 @@
+{
+    "owner": {
+        "username": "simbiont-ai",
+        "email": "TODO-SHEF-EMAIL"
+    },
+    "target": {
+        "CNAME": {
+            "name": "helloplainly",
+            "value": "simbiont-ai.github.io"
+        }
+    },
+    "proxied": false
+}


### PR DESCRIPTION
Domain for Plainly — AI lease/contract reviewer (https://github.com/simbiont-ai/plainly). CNAME points to simbiont-ai.github.io which already serves the landing page. Will be used for the Plainly product launch (US/UK/CA renters + SMBs).