### PR TITLE
Add hirepilot.is-a-good.dev subdomain

### DIFF
--- a/domains/hirepilot.json
+++ b/domains/hirepilot.json
@@ -1,0 +1,17 @@
+{
+    "repo": "https://github.com/atharvbidri500-beep/final",
+
+    "owner": {
+        "username": "atharvbidri500-beep",
+        "email": "atharvbidri500@gmail.com"
+    },
+
+    "target": {
+        "CNAME": {
+            "name": "hirepilot",
+            "value": "atharvbidri500-beep.github.io"
+        }
+    },
+
+    "proxied": false
+}


### PR DESCRIPTION
## Domain Request

**Domain:** `hirepilot.is-a-good.dev`
**Record:** CNAME -> `atharvbidri500-beep.github.io`
**Proxied:** false

## Website
Live at **https://hire-pilot-375z.onrender.com** (also previewable at https://atharvbidri500-beep.github.io/final/)

HirePilot is an AI career co-pilot for freshers: resume builder, ATS score, interview practice, job matching, cover letters, and English polishing tools. Built with React + Node.js, fully open-source at https://github.com/atharvbidri500-beep/final.

## Owner
- GitHub: atharvbidri500-beep
- Email: atharvbidri500@gmail.com
