### PR TITLE
Add peewee.is-a-good.dev

### DIFF
--- a/domains/peewee.json
+++ b/domains/peewee.json
@@ -1,0 +1,10 @@
+{
+  "owner": {
+    "username": "gabelossless",
+    "email": "gabelossless@gmail.com"
+  },
+  "record": {
+    "CNAME": "cname.vercel-dns.com"
+  },
+  "repo": "https://github.com/gabelossless/peewee-coin"
+}


### PR DESCRIPTION
Adding `peewee.is-a-good.dev` for the PEEWEE ($PEEWEE) Solana memecoin website, hosted on Vercel.

Repo: https://github.com/gabelossless/peewee-coin