### PR TITLE
Register neobrowser.is-a-good.dev

### DIFF
--- a/domains/neobrowser.json
+++ b/domains/neobrowser.json
@@ -1,0 +1,14 @@
+{
+  "repo": "https://github.com/pitiflautico/neobrowser",
+  "owner": {
+    "username": "pitiflautico",
+    "email": "pitiflautico3@gmail.com"
+  },
+  "target": {
+    "CNAME": {
+      "name": "neobrowser",
+      "value": "pitiflautico.github.io"
+    }
+  },
+  "proxied": false
+}


### PR DESCRIPTION
Hi maintainers,

I'd like to register neobrowser.is-a-good.dev for an open-source MCP server project.

- Subdomain: neobrowser
- Target: pitiflautico.github.io (GitHub Pages)
- Project: https://github.com/pitiflautico/neobrowser
- Purpose: Landing page and docs for NeoBrowser, an MIT-licensed MCP server that drives real Chrome via CDP with opt-in real logged-in sessions.
- Email: pitiflautico3@gmail.com

The site is already reachable at https://pitiflautico.github.io/neobrowser/ and is not commercial. Let me know if anything needs adjusting.