### PR TITLE
oort.is-a-good.dev

### DIFF
--- a/domains/oort.json
+++ b/domains/oort.json
@@ -1,0 +1,17 @@
+{
+  "repo": "https://github.com/faizi44/register-is-a-good.dev",
+
+  "owner": {
+    "username": "faizi44",
+    "email": "tfayiz@gmail.com"
+  },
+
+  "target": {
+    "A": {
+      "name": "oort",
+      "value": ["193.123.83.192"]
+    }
+  },
+
+  "proxied": false
+}


### PR DESCRIPTION
Registering oort.is-a-good.dev for Oort — a self-hosted search and
extraction API I run on my own VPS. The site is the project's
documentation: quickstart, HTTP API reference, architecture, and
configuration. Points at 193.123.83.192 over an A record.


Live now at https://oort.193-123-83-192.sslip.io